### PR TITLE
Fix: default for results_tidy uses wrong variable

### DIFF
--- a/R/01-class.R
+++ b/R/01-class.R
@@ -63,7 +63,7 @@ breg <- new_class("breg",
       config = config,
       models = models,
       results = results %||% data.frame(),
-      results_tidy = results %||% data.frame()
+      results_tidy = results_tidy %||% data.frame()
     )
   }
 )


### PR DESCRIPTION
Fix typo in constructor where results_tidy default value was incorrectly set to results instead of results_tidy.